### PR TITLE
Create development docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ ci:
 	./vendor/bin/ecs check
 fix:
 	./vendor/bin/ecs check --fix
+run:
+	composer install --no-interaction --prefer-dist
+	exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+    symfony-package:
+        container_name: "symfony-package"
+        image: ferror/symfony-image
+        command: ["make", "run"]
+        volumes:
+            - ./:/app:delegated
+        networks:
+            - ferror
+
+networks:
+    ferror:
+        name: ferror
+        driver: bridge
+        ipam:
+            driver: default
+            config:
+                - subnet: 192.168.10.0/24


### PR DESCRIPTION
Speed up your bundle development with this simple trick! `docker-compose.yml` file that will help you handle any PHP version.