### PR TITLE
[AE-306]add AuditLogListener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=7.4",
         "ext-json": "*",
         "doctrine/dbal": "^2.0|^3.0",
-        "symfony/uid": "^5.2"
+        "symfony/uid": "^5.2",
+        "symfony/http-client": "^5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/Event.php
+++ b/src/Event.php
@@ -13,7 +13,7 @@ use Landingi\EventStoreBundle\Event\SourceIp;
 use Landingi\EventStoreBundle\Event\UserUuid;
 use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
 
-final class Event
+class Event
 {
     private EventName $name;
     private EventData $data;

--- a/src/Event.php
+++ b/src/Event.php
@@ -33,13 +33,14 @@ class Event
         AccountUuid $accountUuid,
         UserUuid $userUuid,
         SourceIp $sourceIp = null,
-        AccountUuid $subaccountUuid = null
+        AccountUuid $subaccountUuid = null,
+        CreatedAt $createdAt = null
     ) {
         $this->name = $name;
         $this->data = $data;
         $this->aggregateName = $aggregateName;
         $this->aggregateUuid = $aggregateUuid;
-        $this->createdAt = new CreatedAt(new \DateTime());
+        $this->createdAt = $createdAt ?: new CreatedAt(new \DateTime());
         $this->accountUuid = $accountUuid;
         $this->userUuid = $userUuid;
         $this->sourceIp = $sourceIp;

--- a/src/Event.php
+++ b/src/Event.php
@@ -11,6 +11,7 @@ use Landingi\EventStoreBundle\Event\EventData;
 use Landingi\EventStoreBundle\Event\EventName;
 use Landingi\EventStoreBundle\Event\SourceIp;
 use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
 
 final class Event
 {
@@ -88,5 +89,28 @@ final class Event
     public function getSubaccountUuid(): ?AccountUuid
     {
         return $this->subaccountUuid;
+    }
+
+    public function toAuditLogEvent(EventDataStore $eventDataStore): AuditLogEvent
+    {
+        return new AuditLogEvent(
+            $this->createdAt,
+            $this->name,
+            $this->data,
+            $this->aggregateName,
+            $this->aggregateUuid,
+            $this->accountUuid,
+            $eventDataStore->getAccountName($this->accountUuid),
+            $this->userUuid,
+            $eventDataStore->getUserEmail($this->userUuid),
+            $eventDataStore->getUserRole($this->userUuid),
+            $this->sourceIp,
+            $this->subaccountUuid
+        );
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->name;
     }
 }

--- a/src/Event/AccountName.php
+++ b/src/Event/AccountName.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\Event;
+
+final class AccountName
+{
+    private string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->name;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Event/UserEmail.php
+++ b/src/Event/UserEmail.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\Event;
+
+final class UserEmail
+{
+    private string $email;
+
+    public function __construct(string $email)
+    {
+        $this->email = $email;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->email;
+    }
+
+    public function __toString(): string
+    {
+        return $this->email;
+    }
+}

--- a/src/Event/UserRole.php
+++ b/src/Event/UserRole.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\Event;
+
+final class UserRole
+{
+    private string $role;
+
+    public function __construct(string $role)
+    {
+        $this->role = $role;
+    }
+
+    public function getRole(): string
+    {
+        return $this->role;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->role;
+    }
+
+    public function __toString(): string
+    {
+        return $this->role;
+    }
+}

--- a/src/EventDataStore.php
+++ b/src/EventDataStore.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle;
+
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+
+interface EventDataStore
+{
+    public function getUserRole(UserUuid $userUuid): UserRole;
+
+    public function getUserEmail(UserUuid $userUuid): UserEmail;
+
+    public function getAccountName(AccountUuid $accountUuid): AccountName;
+}

--- a/src/EventDataStore/DbalEventDataStore.php
+++ b/src/EventDataStore/DbalEventDataStore.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventDataStore;
+
+use Doctrine\DBAL\Connection;
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\EventDataStore;
+use RuntimeException;
+
+final class DbalEventDataStore implements EventDataStore
+{
+    private Connection $connection;
+    private array $cache;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+        $this->cache = [];
+    }
+
+    public function getUserRole(UserUuid $userUuid): UserRole
+    {
+        if (false === isset($this->cache[(string) $userUuid])) {
+            $this->fetchUserData($userUuid);
+        }
+
+        return new UserRole($this->cache[(string) $userUuid]['role']);
+    }
+
+    public function getUserEmail(UserUuid $userUuid): UserEmail
+    {
+        if (false === isset($this->cache[(string) $userUuid])) {
+            $this->fetchUserData($userUuid);
+        }
+
+        return new UserEmail($this->cache[(string) $userUuid]['email']);
+    }
+
+    public function getAccountName(AccountUuid $accountUuid): AccountName
+    {
+        if (false === isset($this->cache[(string) $accountUuid])) {
+            $this->fetchAccountData($accountUuid);
+        }
+
+        return new AccountName($this->cache[(string) $accountUuid]['email']);
+    }
+
+    private function fetchUserData(UserUuid $userUuid): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->select('email, role');
+        $query->from('users');
+        $query->where('uuid = :user_uuid');
+        $query->setParameter('user_uuid', (string) $userUuid);
+        $result = $this->connection->executeQuery(
+            $query->getSQL(),
+            $query->getParameters()
+        )->fetchAssociative();
+
+        if (false === is_array($result)) {
+            throw new RuntimeException("Could not fetch user data for UUID: $userUuid");
+        }
+
+        $this->cache[(string) $userUuid] = $result;
+    }
+
+    private function fetchAccountData(AccountUuid $accountUuid): void
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query->select('name');
+        $query->from('accounts');
+        $query->where('uuid = :account_uuid');
+        $query->setParameter('account_uuid', (string) $accountUuid);
+        $result = $this->connection->executeQuery(
+            $query->getSQL(),
+            $query->getParameters()
+        )->fetchAssociative();
+
+        if (false === is_array($result)) {
+            throw new RuntimeException("Could not fetch account data for UUID: $accountUuid");
+        }
+
+        $this->cache[(string) $accountUuid] = $result;
+    }
+}

--- a/src/EventDataStore/InMemoryCachedEventDataStore.php
+++ b/src/EventDataStore/InMemoryCachedEventDataStore.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventDataStore;
+
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\EventDataStore;
+
+final class InMemoryCachedEventDataStore implements EventDataStore
+{
+    private EventDataStore $eventDataStore;
+    private array $cache;
+
+    public function __construct(EventDataStore $eventDataStore)
+    {
+        $this->eventDataStore = $eventDataStore;
+        $this->cache = [];
+    }
+
+    public function getUserRole(UserUuid $userUuid): UserRole
+    {
+        if (false === isset($this->cache[(string) $userUuid]['role'])) {
+            $this->cache[(string) $userUuid]['role'] = $this->eventDataStore->getUserRole($userUuid);
+        }
+
+        return $this->cache[(string) $userUuid]['role'];
+    }
+
+    public function getUserEmail(UserUuid $userUuid): UserEmail
+    {
+        if (false === isset($this->cache[(string) $userUuid]['email'])) {
+            $this->cache[(string) $userUuid]['email'] = $this->eventDataStore->getUserEmail($userUuid);
+        }
+
+        return $this->cache[(string) $userUuid]['email'];
+    }
+
+    public function getAccountName(AccountUuid $accountUuid): AccountName
+    {
+        if (false === isset($this->cache[(string) $accountUuid]['name'])) {
+            $this->cache[(string) $accountUuid]['name'] = $this->eventDataStore->getAccountName($accountUuid);
+        }
+
+        return $this->cache[(string) $accountUuid]['name'];
+    }
+}

--- a/src/EventDataStore/StaticEventDataStore.php
+++ b/src/EventDataStore/StaticEventDataStore.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventDataStore;
+
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\EventDataStore;
+
+final class StaticEventDataStore implements EventDataStore
+{
+    private UserEmail $userEmail;
+    private UserRole $userRole;
+    private AccountName $accountName;
+
+    public function __construct(
+        UserEmail $userEmail,
+        UserRole $userRole,
+        AccountName $accountName
+    ) {
+        $this->userEmail = $userEmail;
+        $this->userRole = $userRole;
+        $this->accountName = $accountName;
+    }
+
+    public function getUserEmail(UserUuid $userUuid): UserEmail
+    {
+        return $this->userEmail;
+    }
+
+    public function getUserRole(UserUuid $userUuid): UserRole
+    {
+        return $this->userRole;
+    }
+
+    public function getAccountName(AccountUuid $accountUuid): AccountName
+    {
+        return $this->accountName;
+    }
+
+    public function setUserEmail(UserEmail $userEmail): void
+    {
+        $this->userEmail = $userEmail;
+    }
+
+    public function setUserRole(UserRole $userRole): void
+    {
+        $this->userRole = $userRole;
+    }
+
+    public function setAccountName(AccountName $accountName): void
+    {
+        $this->accountName = $accountName;
+    }
+}

--- a/src/EventListener/AuditLogListener.php
+++ b/src/EventListener/AuditLogListener.php
@@ -10,109 +10,6 @@ use Landingi\EventStoreBundle\EventDataStore;
 
 final class AuditLogListener implements EventListener
 {
-    private const AUDITLOG_EVENTS = [
-        'variant_save',
-        'variant_published',
-        'variant_archive',
-        'landing_add_variant',
-        'landing_start_ab_test',
-        'landing_edit_ab_test',
-        'landing_stop_ab_test',
-        'landing_select_winner_ab_test',
-        'landing_archive',
-        'landing_restore',
-        'landing_create',
-        'landing_download',
-        'landing_duplicate',
-        'landing_import',
-        'landing_rename',
-        'landing_unpublish',
-        'landing_start_schedule',
-        'landing_stop_schedule',
-        'landing_reset_stats',
-        'lead_edit',
-        'add_javascript',
-        'edit_javascript',
-        'delete_javascript',
-        'toggle_javascript',
-        'popup_new_create',
-        'popup_new_delete',
-        'popup_new_rename',
-        'popup_new_save',
-        'popup_new_publish',
-        'popup_new_unpublish',
-        'popup_new_dashboard_publish',
-        'popup_new_dashboard_unpublish',
-        'popup_new_duplicate',
-        'popup_new_lead_delete',
-        'lightbox_create',
-        'lightbox_rename',
-        'lightbox_delete',
-        'lightbox_duplicate',
-        'lightbox_save',
-        'account_billing_info_change',
-        'account_cancel_subscription',
-        'account_add_font',
-        'account_delete_font',
-        'account_export_lead',
-        'account_archive_lead',
-        'account_delete_lead',
-        'account_restore_lead',
-        'account_enable_feature',
-        'account_disable_feature',
-        'account_create_token',
-        'account_delete_token',
-        'account_create_user',
-        'account_delete_user',
-        'account_add_domain',
-        'account_domain_assign_landing',
-        'account_delete_domain',
-        'account_share_domain',
-        'account_change_timezone',
-        'account_change_package',
-        'account_change_default_landing_language',
-        'agency_edit_user',
-        'agency_remove_user',
-        'agency_give_user_access_to_subaccount',
-        'agency_remove_user_access_to_subaccount',
-        'agency_add_admin',
-        'agency_edit_admin',
-        'agency_delete_admin',
-        'agency_add_subaccount',
-        'agency_activate_subaccount',
-        'agency_deactivate_subaccount',
-        'agency_delete_subaccount',
-        'agency_edit_subaccount',
-        'agency_gallery_create_folder',
-        'agency_gallery_rename_folder',
-        'agency_gallery_delete_folder',
-        'agency_gallery_delete_picture',
-        'agency_gallery_upload_picture',
-        'agency_gallery_moved_picture',
-        'agency_create_template',
-        'agency_restore_template',
-        'agency_archive_template',
-        'agency_duplicate_template',
-        'agency_rename_template',
-        'agency_save_template',
-        'agency_duplicate_landing_to_sub_account',
-        'change_user_email',
-        'log_in',
-        'published',
-        'save',
-        'sms_sent',
-        'phone_verified',
-        'landing_group_page_assigned',
-        'landing_group_page_dismissed',
-        'landing_move',
-        'unsplash_image_import',
-        'account_resource_limit_created',
-        'account_resource_limit_edited',
-        'account_resource_limit_deleted',
-        'account_resource_limit_attached',
-        'account_resource_limit_detached',
-    ];
-
     private EventDataStore $auditLogEventData;
     private AuditLogClient $auditLogClient;
 
@@ -124,12 +21,10 @@ final class AuditLogListener implements EventListener
 
     public function onEvent(Event $event): void
     {
-        if (in_array((string) $event, self::AUDITLOG_EVENTS, true)) {
-            $this->auditLogClient->store(
-                $event->toAuditLogEvent(
-                    $this->auditLogEventData
-                )
-            );
-        }
+        $this->auditLogClient->store(
+            $event->toAuditLogEvent(
+                $this->auditLogEventData
+            )
+        );
     }
 }

--- a/src/EventListener/AuditLogListener.php
+++ b/src/EventListener/AuditLogListener.php
@@ -5,23 +5,23 @@ namespace Landingi\EventStoreBundle\EventListener;
 
 use Landingi\EventStoreBundle\Event;
 use Landingi\EventStoreBundle\EventListener;
-use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
 use Landingi\EventStoreBundle\EventDataStore;
+use Landingi\EventStoreBundle\EventStore;
 
 final class AuditLogListener implements EventListener
 {
     private EventDataStore $auditLogEventData;
-    private AuditLogClient $auditLogClient;
+    private EventStore $eventStore;
 
-    public function __construct(EventDataStore $auditLogEventData, AuditLogClient $auditLogClient)
+    public function __construct(EventDataStore $auditLogEventData, EventStore $eventStore)
     {
         $this->auditLogEventData = $auditLogEventData;
-        $this->auditLogClient = $auditLogClient;
+        $this->eventStore = $eventStore;
     }
 
     public function onEvent(Event $event): void
     {
-        $this->auditLogClient->store(
+        $this->eventStore->store(
             $event->toAuditLogEvent(
                 $this->auditLogEventData
             )

--- a/src/EventListener/AuditLogListener.php
+++ b/src/EventListener/AuditLogListener.php
@@ -1,0 +1,146 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventListener;
+
+use Landingi\EventStoreBundle\Event;
+use Landingi\EventStoreBundle\EventListener;
+use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
+use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
+use Landingi\EventStoreBundle\EventDataStore;
+
+final class AuditLogListener implements EventListener
+{
+    private const AUDITLOG_EVENTS = [
+        'variant_save',
+        'variant_published',
+        'variant_archive',
+        'landing_add_variant',
+        'landing_start_ab_test',
+        'landing_edit_ab_test',
+        'landing_stop_ab_test',
+        'landing_select_winner_ab_test',
+        'landing_archive',
+        'landing_restore',
+        'landing_create',
+        'landing_download',
+        'landing_duplicate',
+        'landing_import',
+        'landing_rename',
+        'landing_unpublish',
+        'landing_start_schedule',
+        'landing_stop_schedule',
+        'landing_reset_stats',
+        'lead_edit',
+        'add_javascript',
+        'edit_javascript',
+        'delete_javascript',
+        'toggle_javascript',
+        'popup_new_create',
+        'popup_new_delete',
+        'popup_new_rename',
+        'popup_new_save',
+        'popup_new_publish',
+        'popup_new_unpublish',
+        'popup_new_dashboard_publish',
+        'popup_new_dashboard_unpublish',
+        'popup_new_duplicate',
+        'popup_new_lead_delete',
+        'lightbox_create',
+        'lightbox_rename',
+        'lightbox_delete',
+        'lightbox_duplicate',
+        'lightbox_save',
+        'account_billing_info_change',
+        'account_cancel_subscription',
+        'account_add_font',
+        'account_delete_font',
+        'account_export_lead',
+        'account_archive_lead',
+        'account_delete_lead',
+        'account_restore_lead',
+        'account_enable_feature',
+        'account_disable_feature',
+        'account_create_token',
+        'account_delete_token',
+        'account_create_user',
+        'account_delete_user',
+        'account_add_domain',
+        'account_domain_assign_landing',
+        'account_delete_domain',
+        'account_share_domain',
+        'account_change_timezone',
+        'account_change_package',
+        'account_change_default_landing_language',
+        'agency_edit_user',
+        'agency_remove_user',
+        'agency_give_user_access_to_subaccount',
+        'agency_remove_user_access_to_subaccount',
+        'agency_add_admin',
+        'agency_edit_admin',
+        'agency_delete_admin',
+        'agency_add_subaccount',
+        'agency_activate_subaccount',
+        'agency_deactivate_subaccount',
+        'agency_delete_subaccount',
+        'agency_edit_subaccount',
+        'agency_gallery_create_folder',
+        'agency_gallery_rename_folder',
+        'agency_gallery_delete_folder',
+        'agency_gallery_delete_picture',
+        'agency_gallery_upload_picture',
+        'agency_gallery_moved_picture',
+        'agency_create_template',
+        'agency_restore_template',
+        'agency_archive_template',
+        'agency_duplicate_template',
+        'agency_rename_template',
+        'agency_save_template',
+        'agency_duplicate_landing_to_sub_account',
+        'change_user_email',
+        'log_in',
+        'published',
+        'save',
+        'sms_sent',
+        'phone_verified',
+        'landing_group_page_assigned',
+        'landing_group_page_dismissed',
+        'landing_move',
+        'unsplash_image_import',
+        'account_resource_limit_created',
+        'account_resource_limit_edited',
+        'account_resource_limit_deleted',
+        'account_resource_limit_attached',
+        'account_resource_limit_detached',
+    ];
+
+    private EventDataStore $auditLogEventData;
+    private AuditLogClient $auditLogClient;
+
+    public function __construct(EventDataStore $auditLogEventData, AuditLogClient $auditLogClient)
+    {
+        $this->auditLogEventData = $auditLogEventData;
+        $this->auditLogClient = $auditLogClient;
+    }
+
+    public function onEvent(Event $event): void
+    {
+        if (in_array((string) $event->getName(), self::AUDITLOG_EVENTS, true)) {
+            $this->auditLogClient->store(
+                new AuditLogEvent(
+                    $event->getName(),
+                    $event->getEventData(),
+                    $event->getAggregateName(),
+                    $event->getAggregateUuid(),
+                    $event->getAccountUuid(),
+                    $this->auditLogEventData->getAccountName($event->getAccountUuid()),
+                    $event->getUserUuid(),
+                    $this->auditLogEventData->getUserEmail($event->getUserUuid()),
+                    $this->auditLogEventData->getUserRole($event->getUserUuid()),
+                    $event->getSourceIp(),
+                    $event->getSubaccountUuid(),
+                )
+            );
+        }
+    }
+}

--- a/src/EventListener/AuditLogListener.php
+++ b/src/EventListener/AuditLogListener.php
@@ -6,7 +6,6 @@ namespace Landingi\EventStoreBundle\EventListener;
 use Landingi\EventStoreBundle\Event;
 use Landingi\EventStoreBundle\EventListener;
 use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
-use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
 use Landingi\EventStoreBundle\EventDataStore;
 
 final class AuditLogListener implements EventListener
@@ -125,21 +124,10 @@ final class AuditLogListener implements EventListener
 
     public function onEvent(Event $event): void
     {
-        if (in_array((string) $event->getName(), self::AUDITLOG_EVENTS, true)) {
+        if (in_array((string) $event, self::AUDITLOG_EVENTS, true)) {
             $this->auditLogClient->store(
-                new AuditLogEvent(
-                    $event->getCreatedAt(),
-                    $event->getName(),
-                    $event->getEventData(),
-                    $event->getAggregateName(),
-                    $event->getAggregateUuid(),
-                    $event->getAccountUuid(),
-                    $this->auditLogEventData->getAccountName($event->getAccountUuid()),
-                    $event->getUserUuid(),
-                    $this->auditLogEventData->getUserEmail($event->getUserUuid()),
-                    $this->auditLogEventData->getUserRole($event->getUserUuid()),
-                    $event->getSourceIp(),
-                    $event->getSubaccountUuid(),
+                $event->toAuditLogEvent(
+                    $this->auditLogEventData
                 )
             );
         }

--- a/src/EventListener/AuditLogListener.php
+++ b/src/EventListener/AuditLogListener.php
@@ -128,6 +128,7 @@ final class AuditLogListener implements EventListener
         if (in_array((string) $event->getName(), self::AUDITLOG_EVENTS, true)) {
             $this->auditLogClient->store(
                 new AuditLogEvent(
+                    $event->getCreatedAt(),
                     $event->getName(),
                     $event->getEventData(),
                     $event->getAggregateName(),

--- a/src/EventListener/AuditLogListener/AuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventListener\AuditLogListener;
+
+interface AuditLogClient
+{
+    public function store(AuditLogEvent $event): void;
+}

--- a/src/EventListener/AuditLogListener/AuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient.php
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace Landingi\EventStoreBundle\EventListener\AuditLogListener;
-
-interface AuditLogClient
-{
-    public function store(AuditLogEvent $event): void;
-}

--- a/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
@@ -10,17 +10,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class SymfonyHttpAuditLogClient implements AuditLogClient
 {
     private string $auditLogApiBaseUrl;
-    private HttpClientInterface $auditLogHttpClient;
+    private HttpClientInterface $auditLogApiHttpClient;
 
-    public function __construct(string $auditLogApiBaseUrl, HttpClientInterface $auditLogHttpClient)
+    public function __construct(string $auditLogApiBaseUrl, HttpClientInterface $auditLogApiHttpClient)
     {
         $this->auditLogApiBaseUrl = $auditLogApiBaseUrl;
-        $this->auditLogHttpClient = $auditLogHttpClient;
+        $this->auditLogApiHttpClient = $auditLogApiHttpClient;
     }
 
     public function store(AuditLogEvent $event): void
     {
-        $this->auditLogHttpClient->request(
+        $this->auditLogApiHttpClient->request(
             'POST',
             "{$this->auditLogApiBaseUrl}/v1/events",
             [

--- a/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
+
+use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
+use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class SymfonyHttpAuditLogClient implements AuditLogClient
+{
+    private string $baseUrl;
+    private HttpClientInterface $httpClient;
+
+    public function __construct(string $baseUrl, HttpClientInterface $httpClient)
+    {
+        $this->baseUrl = $baseUrl;
+        $this->httpClient = $httpClient;
+    }
+
+    public function store(AuditLogEvent $event): void
+    {
+        $this->httpClient->request(
+            'POST',
+            "{$this->baseUrl}/v1/events",
+            [
+                'json' => [
+                    'event_name' => $event->getName(),
+                    'event_data' => $event->getEventData(),
+                    'event_source_ip' => $event->getSourceIp(),
+                    'aggregate_name' => $event->getAggregateName(),
+                    'aggregate_uuid' => $event->getAggregateUuid(),
+                    'account_uuid' => $event->getAccountUuid(),
+                    'account_name' => $event->getAccountName(),
+                    'subaccount_uuid' => $event->getSubaccountUuid(),
+                    'user_uuid' => $event->getUserUuid(),
+                    'user_email' => $event->getUserEmail(),
+                    'user_role' => $event->getUserRole(),
+                    'created_at' => $event->getCreatedAt(),
+                ]
+            ]
+        );
+    }
+}

--- a/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
@@ -23,22 +23,7 @@ final class SymfonyHttpAuditLogClient implements AuditLogClient
         $this->auditLogApiHttpClient->request(
             'POST',
             "{$this->auditLogApiBaseUrl}/v1/events",
-            [
-                'json' => [
-                    'event_name' => $event->getName(),
-                    'event_data' => $event->getEventData(),
-                    'event_source_ip' => $event->getSourceIp(),
-                    'aggregate_name' => $event->getAggregateName(),
-                    'aggregate_uuid' => $event->getAggregateUuid(),
-                    'account_uuid' => $event->getAccountUuid(),
-                    'account_name' => $event->getAccountName(),
-                    'subaccount_uuid' => $event->getSubaccountUuid(),
-                    'user_uuid' => $event->getUserUuid(),
-                    'user_email' => $event->getUserEmail(),
-                    'user_role' => $event->getUserRole(),
-                    'created_at' => $event->getCreatedAt(),
-                ]
-            ]
+            ['json' => $event]
         );
     }
 }

--- a/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
@@ -9,12 +9,12 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class SymfonyHttpAuditLogClient implements AuditLogClient
 {
-    private string $baseUrl;
+    private string $auditLogApiBaseUrl;
     private HttpClientInterface $httpClient;
 
-    public function __construct(string $baseUrl, HttpClientInterface $httpClient)
+    public function __construct(string $auditLogApiBaseUrl, HttpClientInterface $httpClient)
     {
-        $this->baseUrl = $baseUrl;
+        $this->auditLogApiBaseUrl = $auditLogApiBaseUrl;
         $this->httpClient = $httpClient;
     }
 
@@ -22,7 +22,7 @@ final class SymfonyHttpAuditLogClient implements AuditLogClient
     {
         $this->httpClient->request(
             'POST',
-            "{$this->baseUrl}/v1/events",
+            "{$this->auditLogApiBaseUrl}/v1/events",
             [
                 'json' => [
                     'event_name' => $event->getName(),

--- a/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
+++ b/src/EventListener/AuditLogListener/AuditLogClient/SymfonyHttpAuditLogClient.php
@@ -10,17 +10,17 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class SymfonyHttpAuditLogClient implements AuditLogClient
 {
     private string $auditLogApiBaseUrl;
-    private HttpClientInterface $httpClient;
+    private HttpClientInterface $auditLogHttpClient;
 
-    public function __construct(string $auditLogApiBaseUrl, HttpClientInterface $httpClient)
+    public function __construct(string $auditLogApiBaseUrl, HttpClientInterface $auditLogHttpClient)
     {
         $this->auditLogApiBaseUrl = $auditLogApiBaseUrl;
-        $this->httpClient = $httpClient;
+        $this->auditLogHttpClient = $auditLogHttpClient;
     }
 
     public function store(AuditLogEvent $event): void
     {
-        $this->httpClient->request(
+        $this->auditLogHttpClient->request(
             'POST',
             "{$this->auditLogApiBaseUrl}/v1/events",
             [

--- a/src/EventListener/AuditLogListener/AuditLogEvent.php
+++ b/src/EventListener/AuditLogListener/AuditLogEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Landingi\EventStoreBundle\EventListener\AuditLogListener;
 
 use JsonSerializable;
+use Landingi\EventStoreBundle\Event;
 use Landingi\EventStoreBundle\Event\AccountUuid;
 use Landingi\EventStoreBundle\Event\AggregateName;
 use Landingi\EventStoreBundle\Event\AggregateUuid;
@@ -16,7 +17,7 @@ use Landingi\EventStoreBundle\Event\AccountName;
 use Landingi\EventStoreBundle\Event\UserEmail;
 use Landingi\EventStoreBundle\Event\UserRole;
 
-final class AuditLogEvent implements JsonSerializable
+final class AuditLogEvent extends Event implements JsonSerializable
 {
     private EventName $name;
     private EventData $data;
@@ -57,6 +58,14 @@ final class AuditLogEvent implements JsonSerializable
         $this->accountName = $accountName;
         $this->userEmail = $userEmail;
         $this->userRole = $userRole;
+        parent::__construct(
+            $name,
+            $data,
+            $aggregateName,
+            $aggregateUuid,
+            $accountUuid,
+            $userUuid
+        );
     }
 
     public function jsonSerialize(): array

--- a/src/EventListener/AuditLogListener/AuditLogEvent.php
+++ b/src/EventListener/AuditLogListener/AuditLogEvent.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Landingi\EventStoreBundle\EventListener\AuditLogListener;
 
+use JsonSerializable;
 use Landingi\EventStoreBundle\Event\AccountUuid;
 use Landingi\EventStoreBundle\Event\AggregateName;
 use Landingi\EventStoreBundle\Event\AggregateUuid;
@@ -15,7 +16,7 @@ use Landingi\EventStoreBundle\Event\AccountName;
 use Landingi\EventStoreBundle\Event\UserEmail;
 use Landingi\EventStoreBundle\Event\UserRole;
 
-final class AuditLogEvent
+final class AuditLogEvent implements JsonSerializable
 {
     private EventName $name;
     private EventData $data;
@@ -28,7 +29,7 @@ final class AuditLogEvent
     private UserEmail $userEmail;
     private UserRole $userRole;
     private ?SourceIp $sourceIp;
-    private ?AccountUuid $subaccountUuid;
+    private ?AccountUuid $subAccountUuid;
 
     public function __construct(
         CreatedAt $createdAt,
@@ -42,7 +43,7 @@ final class AuditLogEvent
         UserEmail $userEmail,
         UserRole $userRole,
         SourceIp $sourceIp = null,
-        AccountUuid $subaccountUuid = null
+        AccountUuid $subAccountUuid = null
     ) {
         $this->createdAt = $createdAt;
         $this->name = $name;
@@ -52,69 +53,27 @@ final class AuditLogEvent
         $this->accountUuid = $accountUuid;
         $this->userUuid = $userUuid;
         $this->sourceIp = $sourceIp;
-        $this->subaccountUuid = $subaccountUuid;
+        $this->subAccountUuid = $subAccountUuid;
         $this->accountName = $accountName;
         $this->userEmail = $userEmail;
         $this->userRole = $userRole;
     }
 
-    public function getName(): EventName
+    public function jsonSerialize(): array
     {
-        return $this->name;
-    }
-
-    public function getEventData(): EventData
-    {
-        return $this->data;
-    }
-
-    public function getAggregateName(): AggregateName
-    {
-        return $this->aggregateName;
-    }
-
-    public function getAggregateUuid(): AggregateUuid
-    {
-        return $this->aggregateUuid;
-    }
-
-    public function getCreatedAt(): CreatedAt
-    {
-        return $this->createdAt;
-    }
-
-    public function getAccountUuid(): AccountUuid
-    {
-        return $this->accountUuid;
-    }
-
-    public function getAccountName(): AccountName
-    {
-        return $this->accountName;
-    }
-
-    public function getUserUuid(): UserUuid
-    {
-        return $this->userUuid;
-    }
-
-    public function getUserEmail(): UserEmail
-    {
-        return $this->userEmail;
-    }
-
-    public function getUserRole(): UserRole
-    {
-        return $this->userRole;
-    }
-
-    public function getSourceIp(): ?SourceIp
-    {
-        return $this->sourceIp;
-    }
-
-    public function getSubaccountUuid(): ?AccountUuid
-    {
-        return $this->subaccountUuid;
+        return [
+            'event_name' => $this->name,
+            'event_data' => $this->data,
+            'event_source_ip' => $this->sourceIp,
+            'aggregate_name' => $this->aggregateName,
+            'aggregate_uuid' => $this->aggregateUuid,
+            'account_uuid' => $this->accountUuid,
+            'account_name' => $this->accountName,
+            'subaccount_uuid' => $this->subAccountUuid,
+            'user_uuid' => $this->userUuid,
+            'user_email' => $this->userEmail,
+            'user_role' => $this->userRole,
+            'created_at' => $this->createdAt,
+        ];
     }
 }

--- a/src/EventListener/AuditLogListener/AuditLogEvent.php
+++ b/src/EventListener/AuditLogListener/AuditLogEvent.php
@@ -1,0 +1,119 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventListener\AuditLogListener;
+
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\AggregateName;
+use Landingi\EventStoreBundle\Event\AggregateUuid;
+use Landingi\EventStoreBundle\Event\CreatedAt;
+use Landingi\EventStoreBundle\Event\EventData;
+use Landingi\EventStoreBundle\Event\EventName;
+use Landingi\EventStoreBundle\Event\SourceIp;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+
+final class AuditLogEvent
+{
+    private EventName $name;
+    private EventData $data;
+    private AggregateName $aggregateName;
+    private AggregateUuid $aggregateUuid;
+    private CreatedAt $createdAt;
+    private AccountUuid $accountUuid;
+    private AccountName $accountName;
+    private UserUuid $userUuid;
+    private UserEmail $userEmail;
+    private UserRole $userRole;
+    private ?SourceIp $sourceIp;
+    private ?AccountUuid $subaccountUuid;
+
+    public function __construct(
+        EventName $name,
+        EventData $data,
+        AggregateName $aggregateName,
+        AggregateUuid $aggregateUuid,
+        AccountUuid $accountUuid,
+        AccountName $accountName,
+        UserUuid $userUuid,
+        UserEmail $userEmail,
+        UserRole $userRole,
+        SourceIp $sourceIp = null,
+        AccountUuid $subaccountUuid = null
+    ) {
+        $this->name = $name;
+        $this->data = $data;
+        $this->aggregateName = $aggregateName;
+        $this->aggregateUuid = $aggregateUuid;
+        $this->createdAt = new CreatedAt(new \DateTime());
+        $this->accountUuid = $accountUuid;
+        $this->userUuid = $userUuid;
+        $this->sourceIp = $sourceIp;
+        $this->subaccountUuid = $subaccountUuid;
+        $this->accountName = $accountName;
+        $this->userEmail = $userEmail;
+        $this->userRole = $userRole;
+    }
+
+    public function getName(): EventName
+    {
+        return $this->name;
+    }
+
+    public function getEventData(): EventData
+    {
+        return $this->data;
+    }
+
+    public function getAggregateName(): AggregateName
+    {
+        return $this->aggregateName;
+    }
+
+    public function getAggregateUuid(): AggregateUuid
+    {
+        return $this->aggregateUuid;
+    }
+
+    public function getCreatedAt(): CreatedAt
+    {
+        return $this->createdAt;
+    }
+
+    public function getAccountUuid(): AccountUuid
+    {
+        return $this->accountUuid;
+    }
+
+    public function getAccountName(): AccountName
+    {
+        return $this->accountName;
+    }
+
+    public function getUserUuid(): UserUuid
+    {
+        return $this->userUuid;
+    }
+
+    public function getUserEmail(): UserEmail
+    {
+        return $this->userEmail;
+    }
+
+    public function getUserRole(): UserRole
+    {
+        return $this->userRole;
+    }
+
+    public function getSourceIp(): ?SourceIp
+    {
+        return $this->sourceIp;
+    }
+
+    public function getSubaccountUuid(): ?AccountUuid
+    {
+        return $this->subaccountUuid;
+    }
+}

--- a/src/EventListener/AuditLogListener/AuditLogEvent.php
+++ b/src/EventListener/AuditLogListener/AuditLogEvent.php
@@ -31,6 +31,7 @@ final class AuditLogEvent
     private ?AccountUuid $subaccountUuid;
 
     public function __construct(
+        CreatedAt $createdAt,
         EventName $name,
         EventData $data,
         AggregateName $aggregateName,
@@ -43,11 +44,11 @@ final class AuditLogEvent
         SourceIp $sourceIp = null,
         AccountUuid $subaccountUuid = null
     ) {
+        $this->createdAt = $createdAt;
         $this->name = $name;
         $this->data = $data;
         $this->aggregateName = $aggregateName;
         $this->aggregateUuid = $aggregateUuid;
-        $this->createdAt = new CreatedAt(new \DateTime());
         $this->accountUuid = $accountUuid;
         $this->userUuid = $userUuid;
         $this->sourceIp = $sourceIp;

--- a/src/EventListener/AuditLogListener/AuditLogEvent.php
+++ b/src/EventListener/AuditLogListener/AuditLogEvent.php
@@ -64,7 +64,10 @@ final class AuditLogEvent extends Event implements JsonSerializable
             $aggregateName,
             $aggregateUuid,
             $accountUuid,
-            $userUuid
+            $userUuid,
+            $sourceIp,
+            $subAccountUuid,
+            $createdAt
         );
     }
 

--- a/src/EventListener/InMemoryListener.php
+++ b/src/EventListener/InMemoryListener.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventListener;
+
+use Landingi\EventStoreBundle\Event;
+use Landingi\EventStoreBundle\EventListener;
+
+final class InMemoryListener implements EventListener
+{
+    private array $events;
+
+    public function __construct()
+    {
+        $this->events = [];
+    }
+
+    public function onEvent(Event $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @return Event[]
+     */
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+}

--- a/src/EventListener/StrictAuditLogListener.php
+++ b/src/EventListener/StrictAuditLogListener.php
@@ -1,0 +1,127 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\EventStoreBundle\EventListener;
+
+use Landingi\EventStoreBundle\Event;
+use Landingi\EventStoreBundle\EventListener;
+
+final class StrictAuditLogListener implements EventListener
+{
+    private const AUDITLOG_EVENTS = [
+        'variant_save',
+        'variant_published',
+        'variant_archive',
+        'landing_add_variant',
+        'landing_start_ab_test',
+        'landing_edit_ab_test',
+        'landing_stop_ab_test',
+        'landing_select_winner_ab_test',
+        'landing_archive',
+        'landing_restore',
+        'landing_create',
+        'landing_download',
+        'landing_duplicate',
+        'landing_import',
+        'landing_rename',
+        'landing_unpublish',
+        'landing_start_schedule',
+        'landing_stop_schedule',
+        'landing_reset_stats',
+        'lead_edit',
+        'add_javascript',
+        'edit_javascript',
+        'delete_javascript',
+        'toggle_javascript',
+        'popup_new_create',
+        'popup_new_delete',
+        'popup_new_rename',
+        'popup_new_save',
+        'popup_new_publish',
+        'popup_new_unpublish',
+        'popup_new_dashboard_publish',
+        'popup_new_dashboard_unpublish',
+        'popup_new_duplicate',
+        'popup_new_lead_delete',
+        'lightbox_create',
+        'lightbox_rename',
+        'lightbox_delete',
+        'lightbox_duplicate',
+        'lightbox_save',
+        'account_billing_info_change',
+        'account_cancel_subscription',
+        'account_add_font',
+        'account_delete_font',
+        'account_export_lead',
+        'account_archive_lead',
+        'account_delete_lead',
+        'account_restore_lead',
+        'account_enable_feature',
+        'account_disable_feature',
+        'account_create_token',
+        'account_delete_token',
+        'account_create_user',
+        'account_delete_user',
+        'account_add_domain',
+        'account_domain_assign_landing',
+        'account_delete_domain',
+        'account_share_domain',
+        'account_change_timezone',
+        'account_change_package',
+        'account_change_default_landing_language',
+        'agency_edit_user',
+        'agency_remove_user',
+        'agency_give_user_access_to_subaccount',
+        'agency_remove_user_access_to_subaccount',
+        'agency_add_admin',
+        'agency_edit_admin',
+        'agency_delete_admin',
+        'agency_add_subaccount',
+        'agency_activate_subaccount',
+        'agency_deactivate_subaccount',
+        'agency_delete_subaccount',
+        'agency_edit_subaccount',
+        'agency_gallery_create_folder',
+        'agency_gallery_rename_folder',
+        'agency_gallery_delete_folder',
+        'agency_gallery_delete_picture',
+        'agency_gallery_upload_picture',
+        'agency_gallery_moved_picture',
+        'agency_create_template',
+        'agency_restore_template',
+        'agency_archive_template',
+        'agency_duplicate_template',
+        'agency_rename_template',
+        'agency_save_template',
+        'agency_duplicate_landing_to_sub_account',
+        'change_user_email',
+        'log_in',
+        'published',
+        'save',
+        'sms_sent',
+        'phone_verified',
+        'landing_group_page_assigned',
+        'landing_group_page_dismissed',
+        'landing_move',
+        'unsplash_image_import',
+        'account_resource_limit_created',
+        'account_resource_limit_edited',
+        'account_resource_limit_deleted',
+        'account_resource_limit_attached',
+        'account_resource_limit_detached',
+    ];
+
+    private EventListener $eventListener;
+
+    public function __construct(EventListener $eventListener)
+    {
+        $this->eventListener = $eventListener;
+    }
+
+    public function onEvent(Event $event): void
+    {
+        if (in_array((string) $event, self::AUDITLOG_EVENTS, true)) {
+            $this->eventListener->onEvent($event);
+        }
+    }
+}

--- a/src/EventStore/MemoryEventStore.php
+++ b/src/EventStore/MemoryEventStore.php
@@ -17,4 +17,12 @@ final class MemoryEventStore implements EventStore
     {
         $this->events[] = $event;
     }
+
+    /**
+     * @return array|Event[]
+     */
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
 }

--- a/src/EventStore/SymfonyHttpAuditLogStore.php
+++ b/src/EventStore/SymfonyHttpAuditLogStore.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
 
-namespace Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
+namespace Landingi\EventStoreBundle\EventStore;
 
-use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogClient;
-use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
+use Landingi\EventStoreBundle\Event;
+use Landingi\EventStoreBundle\EventStore;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class SymfonyHttpAuditLogClient implements AuditLogClient
+final class SymfonyHttpAuditLogStore implements EventStore
 {
     private string $auditLogApiBaseUrl;
     private HttpClientInterface $auditLogApiHttpClient;
@@ -18,7 +18,7 @@ final class SymfonyHttpAuditLogClient implements AuditLogClient
         $this->auditLogApiHttpClient = $auditLogApiHttpClient;
     }
 
-    public function store(AuditLogEvent $event): void
+    public function store(Event $event): void
     {
         $this->auditLogApiHttpClient->request(
             'POST',

--- a/tests/EventDataStore/InMemoryCachedEventDataStoreTest.php
+++ b/tests/EventDataStore/InMemoryCachedEventDataStoreTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Landingi\EventStoreBundle\EventDataStore;
+
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class InMemoryCachedEventDataStoreTest extends TestCase
+{
+    public function testCache(): void
+    {
+        $userUuid = new UserUuid(Uuid::v4());
+        $accountUuid = new AccountUuid(Uuid::v4());
+        $cache = new InMemoryCachedEventDataStore(
+            $dataStore = new StaticEventDataStore(
+                new UserEmail('admin@example.com'),
+                new UserRole('ADMIN'),
+                new AccountName('Admin')
+            )
+        );
+
+        // assert data is valid
+        self::assertEquals(
+            new UserEmail('admin@example.com'),
+            $cache->getUserEmail($userUuid)
+        );
+        self::assertEquals(
+            new UserRole('ADMIN'),
+            $cache->getUserRole($userUuid)
+        );
+        self::assertEquals(
+            new AccountName('Admin'),
+            $cache->getAccountName($accountUuid)
+        );
+
+        // change data
+        $dataStore->setUserEmail(new UserEmail('user@example.com'));
+        $dataStore->setUserRole(new UserRole('USER'));
+        $dataStore->setAccountName(new AccountName('User'));
+
+        // assert data is cached
+        self::assertEquals(
+            new UserEmail('admin@example.com'),
+            $cache->getUserEmail($userUuid)
+        );
+        self::assertEquals(
+            new UserRole('ADMIN'),
+            $cache->getUserRole($userUuid)
+        );
+        self::assertEquals(
+            new AccountName('Admin'),
+            $cache->getAccountName($accountUuid)
+        );
+    }
+}

--- a/tests/EventListener/AuditLogListenerTest.php
+++ b/tests/EventListener/AuditLogListenerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Landingi\EventStoreBundle\EventListener;
+
+use Landingi\EventStoreBundle\Event;
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\AggregateName;
+use Landingi\EventStoreBundle\Event\AggregateUuid;
+use Landingi\EventStoreBundle\Event\EventData;
+use Landingi\EventStoreBundle\Event\EventName;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\EventDataStore\StaticEventDataStore;
+use Landingi\EventStoreBundle\EventStore\MemoryEventStore;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class AuditLogListenerTest extends TestCase
+{
+
+    public function testItTransformEventToAuditLogEvent(): void
+    {
+        $listener = new AuditLogListener(
+            $dataStore = new StaticEventDataStore(
+                new UserEmail('admin@example.com'),
+                new UserRole('ADMIN'),
+                new AccountName('Admin')
+            ),
+            $recorder = new MemoryEventStore()
+        );
+        $listener->onEvent(
+            $event = new Event(
+                new EventName('foobar'),
+                new EventData(['foo' => 'bar']),
+                new AggregateName('account'),
+                new AggregateUuid(Uuid::v4()),
+                new AccountUuid(Uuid::v4()),
+                new UserUuid(Uuid::v4()),
+            )
+        );
+        $auditLogEvent = $event->toAuditLogEvent($dataStore);
+
+        self::assertEquals(
+            [$auditLogEvent],
+            $recorder->getEvents()
+        );
+    }
+}

--- a/tests/EventListener/AuditLogListenerTest.php
+++ b/tests/EventListener/AuditLogListenerTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\Uid\Uuid;
 
 class AuditLogListenerTest extends TestCase
 {
-
     public function testItTransformEventToAuditLogEvent(): void
     {
         $listener = new AuditLogListener(

--- a/tests/EventListener/StrictAuditLogListenerTest.php
+++ b/tests/EventListener/StrictAuditLogListenerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Landingi\EventStoreBundle\EventListener;
+
+use Generator;
+use Landingi\EventStoreBundle\Event;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\AggregateName;
+use Landingi\EventStoreBundle\Event\AggregateUuid;
+use Landingi\EventStoreBundle\Event\EventData;
+use Landingi\EventStoreBundle\Event\EventName;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class StrictAuditLogListenerTest extends TestCase
+{
+    /**
+     * @dataProvider auditLogEventsProvider
+     */
+    public function testItListensOnlyAuditLogEvents(string $eventName): void
+    {
+        $listener = new StrictAuditLogListener(
+            $recorder = new InMemoryListener()
+        );
+        $listener->onEvent(
+            $event = new Event(
+                new EventName($eventName),
+                new EventData(['foo' => 'bar']),
+                new AggregateName('account'),
+                new AggregateUuid(Uuid::v4()),
+                new AccountUuid(Uuid::v4()),
+                new UserUuid(Uuid::v4()),
+            )
+        );
+        self::assertEquals(
+            [$event],
+            $recorder->getEvents()
+        );
+    }
+
+    public function testItDoesNotListenOtherEvents(): void
+    {
+        $listener = new StrictAuditLogListener(
+            $recorder = new InMemoryListener()
+        );
+        $listener->onEvent(
+            new Event(
+                new EventName('foobar'),
+                new EventData(['foo' => 'bar']),
+                new AggregateName('account'),
+                new AggregateUuid(Uuid::v4()),
+                new AccountUuid(Uuid::v4()),
+                new UserUuid(Uuid::v4()),
+            )
+        );
+        self::assertEmpty(
+            $recorder->getEvents()
+        );
+    }
+
+    public function auditLogEventsProvider(): Generator
+    {
+        yield ['variant_save'];
+        yield ['variant_published'];
+        yield ['variant_archive'];
+        yield ['landing_add_variant'];
+        yield ['landing_start_ab_test'];
+        yield ['landing_edit_ab_test'];
+        yield ['landing_stop_ab_test'];
+        yield ['landing_select_winner_ab_test'];
+        yield ['landing_archive'];
+        yield ['landing_restore'];
+        yield ['landing_create'];
+        yield ['landing_download'];
+        yield ['landing_duplicate'];
+        yield ['landing_import'];
+        yield ['landing_rename'];
+        yield ['landing_unpublish'];
+        yield ['landing_start_schedule'];
+        yield ['landing_stop_schedule'];
+        yield ['landing_reset_stats'];
+        yield ['lead_edit'];
+        yield ['add_javascript'];
+        yield ['edit_javascript'];
+        yield ['delete_javascript'];
+        yield ['toggle_javascript'];
+        yield ['popup_new_create'];
+        yield ['popup_new_delete'];
+        yield ['popup_new_rename'];
+        yield ['popup_new_save'];
+        yield ['popup_new_publish'];
+        yield ['popup_new_unpublish'];
+        yield ['popup_new_dashboard_publish'];
+        yield ['popup_new_dashboard_unpublish'];
+        yield ['popup_new_duplicate'];
+        yield ['popup_new_lead_delete'];
+        yield ['lightbox_create'];
+        yield ['lightbox_rename'];
+        yield ['lightbox_delete'];
+        yield ['lightbox_duplicate'];
+        yield ['lightbox_save'];
+        yield ['account_billing_info_change'];
+        yield ['account_cancel_subscription'];
+        yield ['account_add_font'];
+        yield ['account_delete_font'];
+        yield ['account_export_lead'];
+        yield ['account_archive_lead'];
+        yield ['account_delete_lead'];
+        yield ['account_restore_lead'];
+        yield ['account_enable_feature'];
+        yield ['account_disable_feature'];
+        yield ['account_create_token'];
+        yield ['account_delete_token'];
+        yield ['account_create_user'];
+        yield ['account_delete_user'];
+        yield ['account_add_domain'];
+        yield ['account_domain_assign_landing'];
+        yield ['account_delete_domain'];
+        yield ['account_share_domain'];
+        yield ['account_change_timezone'];
+        yield ['account_change_package'];
+        yield ['account_change_default_landing_language'];
+        yield ['agency_edit_user'];
+        yield ['agency_remove_user'];
+        yield ['agency_give_user_access_to_subaccount'];
+        yield ['agency_remove_user_access_to_subaccount'];
+        yield ['agency_add_admin'];
+        yield ['agency_edit_admin'];
+        yield ['agency_delete_admin'];
+        yield ['agency_add_subaccount'];
+        yield ['agency_activate_subaccount'];
+        yield ['agency_deactivate_subaccount'];
+        yield ['agency_delete_subaccount'];
+        yield ['agency_edit_subaccount'];
+        yield ['agency_gallery_create_folder'];
+        yield ['agency_gallery_rename_folder'];
+        yield ['agency_gallery_delete_folder'];
+        yield ['agency_gallery_delete_picture'];
+        yield ['agency_gallery_upload_picture'];
+        yield ['agency_gallery_moved_picture'];
+        yield ['agency_create_template'];
+        yield ['agency_restore_template'];
+        yield ['agency_archive_template'];
+        yield ['agency_duplicate_template'];
+        yield ['agency_rename_template'];
+        yield ['agency_save_template'];
+        yield ['agency_duplicate_landing_to_sub_account'];
+        yield ['change_user_email'];
+        yield ['log_in'];
+        yield ['published'];
+        yield ['save'];
+        yield ['sms_sent'];
+        yield ['phone_verified'];
+        yield ['landing_group_page_assigned'];
+        yield ['landing_group_page_dismissed'];
+        yield ['landing_move'];
+        yield ['unsplash_image_import'];
+        yield ['account_resource_limit_created'];
+        yield ['account_resource_limit_edited'];
+        yield ['account_resource_limit_deleted'];
+        yield ['account_resource_limit_attached'];
+        yield ['account_resource_limit_detached'];
+    }
+}

--- a/tests/EventListener/StrictAuditLogListenerTest.php
+++ b/tests/EventListener/StrictAuditLogListenerTest.php
@@ -33,6 +33,7 @@ class StrictAuditLogListenerTest extends TestCase
                 new UserUuid(Uuid::v4()),
             )
         );
+
         self::assertEquals(
             [$event],
             $recorder->getEvents()
@@ -54,6 +55,7 @@ class StrictAuditLogListenerTest extends TestCase
                 new UserUuid(Uuid::v4()),
             )
         );
+
         self::assertEmpty(
             $recorder->getEvents()
         );

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Landingi\EventStoreBundle;
+
+use DateTime;
+use Landingi\EventStoreBundle\Event\AccountName;
+use Landingi\EventStoreBundle\Event\AccountUuid;
+use Landingi\EventStoreBundle\Event\AggregateName;
+use Landingi\EventStoreBundle\Event\AggregateUuid;
+use Landingi\EventStoreBundle\Event\CreatedAt;
+use Landingi\EventStoreBundle\Event\EventData;
+use Landingi\EventStoreBundle\Event\EventName;
+use Landingi\EventStoreBundle\Event\SourceIp;
+use Landingi\EventStoreBundle\Event\UserEmail;
+use Landingi\EventStoreBundle\Event\UserRole;
+use Landingi\EventStoreBundle\Event\UserUuid;
+use Landingi\EventStoreBundle\EventDataStore\StaticEventDataStore;
+use Landingi\EventStoreBundle\EventListener\AuditLogListener\AuditLogEvent;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class EventTest extends TestCase
+{
+    public function testToAuditLogEvent(): void
+    {
+        $dataStore = new StaticEventDataStore(
+            new UserEmail('admin@example.com'),
+            new UserRole('ADMIN'),
+            new AccountName('Admin')
+        );
+        $event = new Event(
+            new EventName('foo'),
+            new EventData(['foo' => 'bar']),
+            new AggregateName('account'),
+            new AggregateUuid(Uuid::v4()),
+            new AccountUuid(Uuid::v4()),
+            new UserUuid(Uuid::v4()),
+            new SourceIp('0.0.0.0'),
+            new AccountUuid(Uuid::v4()),
+            new CreatedAt(new DateTime())
+        );
+
+        self::assertEquals(
+            new AuditLogEvent(
+                $event->getCreatedAt(),
+                $event->getName(),
+                $event->getEventData(),
+                $event->getAggregateName(),
+                $event->getAggregateUuid(),
+                $event->getAccountUuid(),
+                $dataStore->getAccountName($event->getAccountUuid()),
+                $event->getUserUuid(),
+                $dataStore->getUserEmail($event->getUserUuid()),
+                $dataStore->getUserRole($event->getUserUuid()),
+                $event->getSourceIp(),
+                $event->getSubaccountUuid()
+            ),
+            $event->toAuditLogEvent($dataStore)
+        );
+    }
+}


### PR DESCRIPTION
Use AuditLogListener to store audit-log events in the AuditLog service via its HTTP API. It is recommended to use it along with StricAuditLogListener decorator which controls which events are allowed.