### PR TITLE
[PI-1239]Add useful getter for CreatedAt object

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -52,6 +52,11 @@ class Event
         return $this->name;
     }
 
+    public function getEventName(): string
+    {
+        return $this->name->getName();
+    }
+
     public function getEventData(): EventData
     {
         return $this->data;

--- a/src/Event.php
+++ b/src/Event.php
@@ -52,11 +52,6 @@ class Event
         return $this->name;
     }
 
-    public function getEventName(): string
-    {
-        return $this->name->getName();
-    }
-
     public function getEventData(): EventData
     {
         return $this->data;

--- a/src/Event/CreatedAt.php
+++ b/src/Event/CreatedAt.php
@@ -20,6 +20,11 @@ final class CreatedAt implements JsonSerializable
         return $this->createdAt;
     }
 
+    public function getTimestamp(): int
+    {
+        return $this->createdAt->getTimestamp();
+    }
+
     public function jsonSerialize(): string
     {
         return $this->createdAt->format('Y-m-d H:i:s');

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -58,4 +58,20 @@ class EventTest extends TestCase
             $event->toAuditLogEvent($dataStore)
         );
     }
+
+    public function testGenerateTimestamp(): void
+    {
+        $event = new Event(
+            new EventName('foo'),
+            new EventData(['foo' => 'bar']),
+            new AggregateName('account'),
+            new AggregateUuid(Uuid::v4()),
+            new AccountUuid(Uuid::v4()),
+            new UserUuid(Uuid::v4()),
+            new SourceIp('0.0.0.0'),
+            new AccountUuid(Uuid::v4()),
+            new CreatedAt(new DateTime('2022-02-17'))
+        );
+        $this->assertEquals(1645056000, $event->getCreatedAt()->getTimestamp());
+    }
 }


### PR DESCRIPTION
Thanks to this update it is possible to get created at timestamp directly from CreatedAt object by calling $event->getCreatedAt()->getTimestamp(). Thanks to this change, Event usage will be more object-oriented.