### PR TITLE
[PI-1239]Change Travis CI to GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+    ci:
+        runs-on: ubuntu-20.04
+
+        strategy:
+            matrix:
+                php-versions: ['7.4', '8.0']
+
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php-versions }}
+            -   run: composer install
+            -   run: make ci
+            -   run: bash <(curl -s https://codecov.io/bash) -f "build/coverage.xml" -t ${{ secrets.CODECOV_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: php
-php:
-    - '7.4'
-script:
-    - make ci
-install:
-    - composer install


### PR DESCRIPTION
Travis CI is deprecated, so there is need to change Travis to GitHub actions.