### PR TITLE
[PI-1239]Upgrade bundle to version 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # event-store-bundle
 Landingi Event Store Implementation
+ver. 1.1.1
 
 [![Build Status](https://travis-ci.com/landingi/event-store-bundle.svg?branch=master)](https://travis-ci.com/landingi/event-store-bundle)
 [![License MIT](https://img.shields.io/apm/l/vim-mode.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This upgrade is related to the code provided by PR: [PI-1239]Add useful getter for CreatedAt object #13.
Commit is tagged as version 1.1.1.

[PI-1239]: https://landingi.atlassian.net/browse/PI-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ