### PR TITLE
[OP-1123] Bumped depreciated GHA's 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
                 php-versions: ['7.4', '8.0']
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php-versions }}


### PR DESCRIPTION
[OP-1123] Bumped depreciated GHA's which solved the problem with the message appearing about the transition from node16 to node20

ci.ymal
 actions/checkout@v2 - v4

[OP-1123]: https://landingi.atlassian.net/browse/OP-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ